### PR TITLE
JWT Adapter #19

### DIFF
--- a/src/Adapter/JwtAdapter.php
+++ b/src/Adapter/JwtAdapter.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @see       https://github.com/laminas/laminas-authentication for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-authentication/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-authentication/blob/master/LICENSE.md New BSD License
+ */
+namespace Laminas\Authentication\Adapter;
+
+use Laminas\Authentication\Adapter\AdapterInterface;
+use Laminas\Authentication\Result;
+use Laminas\Authentication\Jwt;
+
+class JwtAdapter implements AdapterInterface
+{
+
+    /** @var string **/
+    private $token;
+
+    /** @var string **/
+    private $subject;
+
+    /**
+     *
+     * @param string $token
+     * @param string $subject
+     */
+    public function __construct(string $token, string $subject)
+    {
+        $this->token = $token;
+        $this->subject = $subject;
+    }
+
+    /**
+     *
+     * {@inheritdoc}
+     * @see \Laminas\Authentication\Adapter\AdapterInterface::authenticate()
+     */
+    public function authenticate()
+    {
+        $payload = Jwt::getPayload($this->token);
+        $result = Result::FAILURE_IDENTITY_NOT_FOUND;
+        $identity = 'unknown';
+        $messages = [
+            'Failure identity not found'
+        ];
+        if ($payload == false) {
+            $result = Result::FAILURE_CREDENTIAL_INVALID;
+            $messages[] = 'Failure credential invalid';
+        } elseif ($payload->sub == $this->subject) {
+            $result = Result::SUCCESS;
+            $identity = $this->subject;
+        }
+        return new Result($result, $identity, $messages);
+    }
+}

--- a/src/Jwt.php
+++ b/src/Jwt.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types = 1);
+/**
+ *
+ * @see https://github.com/laminas/laminas-authentication for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-authentication/blob/master/COPYRIGHT.md
+ * @license https://github.com/laminas/laminas-authentication/blob/master/LICENSE.md New BSD License
+ */
+namespace Laminas\Authentication;
+
+class Jwt
+{
+
+    /** @var string **/
+    private $alg;
+
+    /** @var string **/
+    private $typ;
+
+    /** @var string **/
+    private $expiresAt;
+
+    /** @var string **/
+    private $privateKeyLocation;
+
+    /**
+     *
+     * @param array $alg
+     *            algorithm
+     * @param string $typ
+     *            token type
+     * @param string $iss
+     *            issuer
+     * @param string $expiresAt
+     *            UNIX timestamp for token expiration
+     * @param string $privateKeyLocation
+     *            path of filesystem for private key file
+     */
+    public function __construct(array $alg, string $typ, string $iss, string $expiresAt, string $privateKeyLocation = null)
+    {
+        $this->alg = $alg;
+        $this->typ = $typ;
+        $this->iss = $iss;
+        $this->expiresAt = $expiresAt;
+        $this->privateKeyLocation = $privateKeyLocation;
+    }
+
+    /**
+     *
+     * @param string $subject
+     *            token subject
+     * @param string $credential
+     *            user credential
+     * @param array $payloadAdditionalParameters
+     *            claims
+     * @return string
+     */
+    public function getBearerToken(string $subject, string $credential = null, array $payloadAdditionalParameters = null): string
+    {
+        $header = [
+            'alg' => $this->alg[0],
+            'typ' => $this->typ
+        ];
+        $header = json_encode($header);
+        $header = base64_encode($header);
+        $date = date_create();
+        $iat = date_timestamp_get($date);
+        $date->add(new \DateInterval($this->expiresAt));
+        $exp = date_timestamp_get($date);
+        $payload = [
+            'exp' => $exp,
+            'iat' => $iat,
+            'iss' => $this->iss,
+            'sub' => $subject
+        ];
+        if (! is_null($payloadAdditionalParameters)) {
+            $payload = array_merge($payload, $payloadAdditionalParameters);
+        }
+        $payload = json_encode($payload);
+        $payload = base64_encode($payload);
+        $rsaPrivateKey = (is_null($credential) ? file_get_contents($this->privateKeyLocation) : $credential);
+        $signature = hash_hmac($this->alg[1], "$header.$payload", $rsaPrivateKey, true);
+        $signature = base64_encode($signature);
+        return "$header.$payload.$signature";
+    }
+
+    /**
+     *
+     * @param string $token
+     * @return object
+     * @throws \Exception
+     */
+    public static function getPayload(string $token): object
+    {
+        $part = explode(".", $token);
+        if (count($part) < 3) {
+            throw new \Exception('token has not enough parts:' . count($part));
+        }
+        return json_decode(base64_decode($part[1]));
+    }
+
+    /**
+     *
+     * @param string $token
+     * @return bool
+     */
+    public static function expired(string $token): bool
+    {
+        $payload = self::getPayload($token);
+        if ($payload == false) {
+            return true;
+        }
+        $currentTimestamp = date_timestamp_get(date_create());
+        if ($currentTimestamp > $payload->exp) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/test/Adapter/JwtAdapterTest.php
+++ b/test/Adapter/JwtAdapterTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @see       https://github.com/laminas/laminas-authentication for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-authentication/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-authentication/blob/master/LICENSE.md New BSD License
+ */
+namespace LaminasTest\Authentication\Adapter;
+
+use Laminas\Authentication\Adapter\JwtAdapter;
+use PHPUnit\Framework\TestCase;
+use Laminas\Authentication\AuthenticationService;
+
+/**
+ * test case.
+ */
+class JwtAdapterTest extends TestCase
+{
+
+    public function testAdapter(): void
+    {
+        // Data from https://jwt.io/
+        $token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+        $subject = '1234567890';
+        $adapter = new JwtAdapter($token, $subject);
+        $authentication = new AuthenticationService();
+        $authentication->setAdapter($adapter);
+        $result = $authentication->authenticate();
+        $this->assertTrue($result->isValid());
+    }
+}
+

--- a/test/Model/JwtTest.php
+++ b/test/Model/JwtTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @see       https://github.com/laminas/laminas-authentication for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-authentication/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-authentication/blob/master/LICENSE.md New BSD License
+ */
+use PHPUnit\Framework\TestCase;
+use Laminas\Authentication\Jwt;
+
+/**
+ * test case.
+ */
+class JwtTest extends TestCase
+{
+
+    public function testBearerToken(): void
+    {
+        $jwt = new Jwt([
+            'RS256',
+            'sha256'
+        ], 'JWT', 'newbraveworld.com', 'PT2H');
+
+        $bearerToken = $jwt->getBearerToken('foouser', 'baapassword');
+
+        $this->assertTrue(is_string($bearerToken));
+        $this->assertNotEmpty($bearerToken);
+
+        $payload = Jwt::getPayload($bearerToken);
+
+        $this->assertTrue(is_object($payload));
+
+        $this->assertFalse(Jwt::expired($bearerToken));
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | no

### Description

- This feature request adds something the library currently does not support: JWT authentication.
  - This should be added because JWT is a pattern specification (RFC 7519) and microservice based applications can be use it
  - Applications with JWT authentication as requirement will enable it
  - This code be used in microservice applications or sessionless applications.
  - TARGET THE develop BRANCH
