### PR TITLE
Removed dependency on laminas/laminas-zendframework-bridge

### DIFF
--- a/.laminas-ci/phpunit.xml
+++ b/.laminas-ci/phpunit.xml
@@ -1,30 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="laminas-authentication Test Suite">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-
-    <php>
-        <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_PDO_SQLITE_ENABLED" value="true" />
-        <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_PDO_SQLITE_DATABASE" value=":memory:" />
-        <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_ENABLED" value="false" />
-        <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_HOSTNAME" value="127.0.0.1" />
-        <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_PORT" value="50000" />
-        <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_USERNAME" value="" />
-        <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_PASSWORD" value="" />
-        <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_DATABASE" value="*LOCAL" />
-        <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_CREDENTIAL_TABLE" value="YOURLIB.TESTING_USERS" />
-        <env name="TESTS_LAMINAS_AUTH_ADAPTER_LDAP_ONLINE_ENABLED" value="false" />
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" convertDeprecationsToExceptions="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="laminas-authentication Test Suite">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_PDO_SQLITE_ENABLED" value="true"/>
+    <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_PDO_SQLITE_DATABASE" value=":memory:"/>
+    <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_ENABLED" value="false"/>
+    <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_HOSTNAME" value="127.0.0.1"/>
+    <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_PORT" value="50000"/>
+    <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_USERNAME" value=""/>
+    <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_PASSWORD" value=""/>
+    <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_DATABASE" value="*LOCAL"/>
+    <env name="TESTS_LAMINAS_AUTH_ADAPTER_DBTABLE_DB2_CREDENTIAL_TABLE" value="YOURLIB.TESTING_USERS"/>
+    <env name="TESTS_LAMINAS_AUTH_ADAPTER_LDAP_ONLINE_ENABLED" value="false"/>
+  </php>
 </phpunit>

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
     },
     "require": {
         "php": "^7.3 || ~8.0.0",
-        "laminas/laminas-stdlib": "^3.2.1",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-stdlib": "^3.2.1"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
@@ -70,7 +69,7 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
-    "replace": {
-        "zendframework/zend-authentication": "^2.7.0"
+    "conflict": {
+        "zendframework/zend-authentication": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "286d58b57d2cb1a4a9f386ac2285a236",
+    "content-hash": "5bcaa32d9a797266d206df5a9ca72381",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",
@@ -66,23 +66,23 @@
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.2.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "6cccbddfcfc742eb02158d6137ca5687d92cee32"
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6cccbddfcfc742eb02158d6137ca5687d92cee32",
-                "reference": "6cccbddfcfc742eb02158d6137ca5687d92cee32",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
+                "phpunit/phpunit": "^9.3",
                 "psalm/plugin-phpunit": "^0.15.1",
                 "squizlabs/php_codesniffer": "^3.5",
                 "vimeo/psalm": "^4.6"
@@ -124,7 +124,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-25T21:54:58+00:00"
+            "time": "2021-09-03T17:53:30+00:00"
         }
     ],
     "packages-dev": [
@@ -4742,5 +4742,5 @@
         "php": "^7.3 || ~8.0.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         colors="true">
+         colors="true"
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="laminas-authentication Test Suite">
             <directory>./test</directory>


### PR DESCRIPTION
Removed dependency on laminas/laminas-zendframework-bridge
This should increase performance once other laminas packages do so too.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | yes
