### PR TITLE
Deprecate Digest adapter

### DIFF
--- a/.laminas-ci/pre-install.sh
+++ b/.laminas-ci/pre-install.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-WORKING_DIRECTORY=$2
-JOB=$3
-PHP_VERSION=$(echo "${JOB}" | jq -r '.php')
-
-apt install -y php8.1-ldap || exit 1

--- a/docs/book/adapter/digest.md
+++ b/docs/book/adapter/digest.md
@@ -20,6 +20,16 @@ which the password is "somePassword"):
 someUser:Some Realm:fde17b91c3a510ecbaf7dbd37f59d4f8
 ```
 
+> CAUTION: **Digest Authentication Security Issues**
+>
+> Digest authentication utilizes `md5()` for hash creation and hash comparisons by default.
+> While the [HTDigest specification](https://datatracker.ietf.org/doc/html/rfc7616) has been expanded to allow SHA-256 and SHA-512 hashing algorithms, they require a different tool for the digest password file, as well as for the server-side to emit a header indicating what algorithm is in use.
+> We plan to add new adapters to support SHA-256 and/or SHA-512 in version 3, but continue to provide the original Digest implementation here to ensure compatibility with existing tooling.
+>
+> However, we **strongly urge** users to use our Basic authentication, LDAP, DB table, or custom authentication adapters (preferably utilizing `password_hash()`/`password_verify()`) to prevent attack vectors common to the Digest algorithm.
+>
+> This adapter is deprecated as of version 2.10.0, and will be removed in version 3.0.0.
+
 ## Specifics
 
 The digest authentication adapter, `Laminas\Authentication\Adapter\Digest`,

--- a/src/Adapter/Digest.php
+++ b/src/Adapter/Digest.php
@@ -12,6 +12,13 @@ use Laminas\Authentication\Result as AuthenticationResult;
 use Laminas\Crypt\Utils as CryptUtils;
 use Laminas\Stdlib\ErrorHandler;
 
+/**
+ * @deprecated Since 2.10.0; to be removed in 3.0.0. Digest authentication has
+*     known security issues due to the usage of MD5 for hash comparisons.
+*     We recommend usage of HTTP Basic, LDAP, DbTable, or a custom adapter that
+*     makes usage of strong hashing algorithms, preferably via usage of
+*     password_hash and password_verify.
+*/
 class Digest extends AbstractAdapter
 {
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | yes (future)
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The Digest adapter uses the legacy MD5 algorithm for hashing, per standard tooling such as the `htdigest` tool provided by the Apache web server.
While the specification has been updated to allow for SHA-256 and SHA-512, these would (a) require changes to how we request and validate credentials, and (b) changes to how the file is generated, and should likely have their own dedicated adapters.
Additionally, moving to one or both of those and immediately deprecating the existing functionality would break existing sites that were built with htdigest.
As such, this patch **deprecates** the Digest adapter, and notes the security concerns leading to that deprecation.
